### PR TITLE
Fix mobile app layout issues with status bar overlap

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       postcss:
         specifier: 8.4.49
         version: 8.4.49
+      sharp:
+        specifier: ^0.32.1
+        version: 0.32.6
       tailwindcss:
         specifier: 3.4.16
         version: 3.4.16(ts-node@10.9.2(@types/node@24.6.2)(typescript@5.9.3))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,6 @@ function AppWithBackHandler() {
   return (
     <div
       style={{
-        paddingTop: "env(safe-area-inset-top, 0px)", // respect safe area inset, no extra gap
         boxSizing: "border-box",
         minHeight: "100%",
         backgroundColor: "#fff",

--- a/src/BulkEdit.jsx
+++ b/src/BulkEdit.jsx
@@ -148,7 +148,7 @@ useEffect(() => {
   }
   console.log("imageMap", imageMap);
   return (
-  <div className="fixed inset-0 bg-white z-50 flex flex-col pt-[env(safe-area-inset-top,0px)]">
+  <div className="fixed inset-0 bg-white z-50 flex flex-col">
     <header className="shrink-0 bg-white shadow-sm border-b z-10 px-4 py-2 flex items-center justify-between">
   <h1 className="text-lg sm:text-xl font-semibold text-gray-800 tracking-tight">
     🛠️ Bulk Editor

--- a/src/CatalogueApp.tsx
+++ b/src/CatalogueApp.tsx
@@ -242,7 +242,6 @@ export default function CatalogueApp({ products, setProducts, deletedProducts, s
   return (
     <div
       className="w-full h-screen flex flex-col bg-gradient-to-b from-white to-gray-100 relative"
-      style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
     >
 
       {tab === "products" && (
@@ -627,7 +626,7 @@ export default function CatalogueApp({ products, setProducts, deletedProducts, s
         )}
       </main>
 
-      <nav className="fixed bottom-0 left-0 right-0 z-30 flex justify-around text-sm font-medium">
+      <nav className="fixed bottom-0 left-0 right-0 z-30 flex justify-around text-sm font-medium pb-[env(safe-area-inset-bottom,0px)]">
         {[
           { key: "products", label: "Products", color: "bg-blue-500 text-white" },
           { key: "wholesale", label: "Wholesale", color: "bg-blue-500 text-white" },
@@ -656,7 +655,8 @@ export default function CatalogueApp({ products, setProducts, deletedProducts, s
           await Haptics.impact({ style: ImpactStyle.Medium });
           navigate("/create");
         }}
-        className="fixed bottom-16 right-4 z-40 bg-blue-600 text-white p-4 rounded-full shadow-lg hover:scale-105 transition"
+        className="fixed right-4 z-40 bg-blue-600 text-white p-4 rounded-full shadow-lg hover:scale-105 transition"
+        style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 64px)' }}
       >
         <FiPlus size={24} />
       </button>

--- a/src/CreateProduct.tsx
+++ b/src/CreateProduct.tsx
@@ -280,11 +280,10 @@ setTimeout(async () => {
 
   const handleCancel = () => navigate("/");
   return (
-    <div className="px-4 pt-[env(safe-area-inset-top)] max-w-lg mx-auto text-sm"
+    <div className="px-4 max-w-lg mx-auto text-sm"
     >
       <header 
   className="sticky top-0 z-40 bg-white/90 backdrop-blur-sm border-b border-gray-200 py-3 text-center font-bold text-lg"
-  style={{ paddingTop: "env(safe-area-inset-top, 12px)" }}
 >
   {editingId ? "Edit Product" : "Create Product"}
 </header>

--- a/src/MediaEditor.jsx
+++ b/src/MediaEditor.jsx
@@ -178,7 +178,7 @@ export default function MediaEditor({ image, onClose, onSave }) {
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
     >
-      <div className="flex justify-between items-center px-4 py-2 border-b border-gray-700 bg-black pt-[env(safe-area-inset-top)]">
+      <div className="flex justify-between items-center px-4 py-2 border-b border-gray-700 bg-black">
         <button onClick={onClose} className="text-blue-400">Cancel</button>
         <div className="text-xs uppercase text-gray-400">{tab}</div>
         <button onClick={handleSave} className="text-blue-400">Done</button>

--- a/src/MediaLibrary.jsx
+++ b/src/MediaLibrary.jsx
@@ -108,8 +108,8 @@ export default function MediaLibrary({ onSelect, onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-white pt-[env(safe-area-inset-top)] overflow-y-auto">
-      <div className="sticky bg-white p-4 border-b z-10 flex items-center justify-between shadow" style={{ top: 'env(safe-area-inset-top, 0px)' }}>
+    <div className="fixed inset-0 z-50 bg-white overflow-y-auto">
+      <div className="sticky top-0 bg-white p-4 border-b z-10 flex items-center justify-between shadow">
         <h2 className="text-xl font-semibold">Media Library</h2>
         <div className="flex gap-4 items-center text-xl">
           {selectMode ? (

--- a/src/ProductPreviewModal.jsx
+++ b/src/ProductPreviewModal.jsx
@@ -231,7 +231,7 @@ const FullScreenImageViewer = ({ imageUrl, productName, isOpen, onClose }) => {
   return (
     <div className="fixed inset-0 z-[60] bg-black flex items-center justify-center">
       {/* Header with close and share buttons */}
-      <div className="absolute left-0 right-0 z-10 flex justify-between items-center p-4 bg-gradient-to-b from-black/50 to-transparent" style={{ top: 'env(safe-area-inset-top, 0px)' }}>
+      <div className="absolute left-0 right-0 z-10 flex justify-between items-center p-4 bg-gradient-to-b from-black/50 to-transparent" style={{ top: 0 }}>
         <button
           onClick={onClose}
           className="text-white hover:text-gray-300 transition-colors p-2 rounded-full bg-black/30 backdrop-blur-sm"

--- a/src/Resell.tsx
+++ b/src/Resell.tsx
@@ -213,7 +213,7 @@ setSelected((prev) => (prev.includes(id) ? prev : [...prev, id]));
 
   return (
     <>
-    <header className="sticky z-40 bg-white/100 backdrop-blur-sm border-b border-gray-200 px-1 py-2 flex items-center gap-3 relative" style={{ top: 'env(safe-area-inset-top, 0px)' }} >
+    <header className="sticky top-0 z-40 bg-white/100 backdrop-blur-sm border-b border-gray-200 px-1 py-2 flex items-center gap-3 relative">
   {/* Menu Button */}
   <AnimatePresence mode="wait" initial={false}>
   {!showSearch && (

--- a/src/Shelf.jsx
+++ b/src/Shelf.jsx
@@ -58,8 +58,8 @@ export default function Shelf({ deletedProducts, setDeletedProducts, setProducts
   };
 
   return (
-    <div className="w-full h-screen flex flex-col bg-gradient-to-b from-white to-gray-100 relative" style={{ paddingTop: "env(safe-area-inset-top)" }}>
-        <header className="sticky top-[env(safe-area-inset-top)] z-40 bg-white/80 backdrop-blur-sm border-b border-gray-200 px-4 py-2 flex items-center gap-3 relative">
+    <div className="w-full h-screen flex flex-col bg-gradient-to-b from-white to-gray-100 relative">
+        <header className="sticky top-0 z-40 bg-white/80 backdrop-blur-sm border-b border-gray-200 px-4 py-2 flex items-center gap-3 relative">
         <button
           onClick={() => setMenuOpen(true)}
           className="text-2xl font-bold text-gray-700"

--- a/src/SideDrawer.jsx
+++ b/src/SideDrawer.jsx
@@ -271,8 +271,8 @@ const exportProductsToCSV = (products) => {
         <div
           className="absolute left-0 w-64 bg-white shadow-lg p-4 overflow-y-auto"
           style={{
-            top: "env(safe-area-inset-top, 0px)",
-            height: "calc(100% - env(safe-area-inset-top, 0px))",
+            top: 0,
+            height: "100%",
           }}
           onClick={(e) => e.stopPropagation()}
         >

--- a/src/Wholesale.tsx
+++ b/src/Wholesale.tsx
@@ -213,7 +213,7 @@ setSelected((prev) => (prev.includes(id) ? prev : [...prev, id]));
 
   return (
     <>
-    <header className="sticky z-40 bg-white/100 backdrop-blur-sm border-b border-gray-200 px-1 py-2 flex items-center gap-3 relative" style={{ top: 'env(safe-area-inset-top, 0px)' }} >
+    <header className="sticky top-0 z-40 bg-white/100 backdrop-blur-sm border-b border-gray-200 px-1 py-2 flex items-center gap-3 relative">
   {/* Menu Button */}
   <AnimatePresence mode="wait" initial={false}>
   {!showSearch && (


### PR DESCRIPTION
## Purpose
Fix mobile app layout issues where the app content goes behind the status bar and resolve inconsistent spacing gaps above various pages (CatalogueApp, CreateProduct, Wholesale, and Resell tabs) when installed through Capacitor.

## Code changes
- **Removed safe area top padding**: Eliminated `paddingTop: "env(safe-area-inset-top, 0px)"` from multiple components (App.tsx, CatalogueApp.tsx, CreateProduct.tsx, BulkEdit.jsx, MediaEditor.jsx, etc.)
- **Updated sticky positioning**: Changed sticky headers to use `top: 0` instead of `top: 'env(safe-area-inset-top, 0px)'`
- **Fixed bottom navigation**: Added proper safe area bottom padding to navigation bar and floating action button
- **Simplified layout structure**: Removed redundant safe area handling that was causing the overlap and spacing issues
- **Added sharp dependency**: Updated pnpm-lock.yaml to include sharp@0.32.6 for image processing

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f59fbb65721b4ded93b149b07eab4b1f/neon-nest)

👀 [Preview Link](https://f59fbb65721b4ded93b149b07eab4b1f-neon-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f59fbb65721b4ded93b149b07eab4b1f</projectId>-->
<!--<branchName>neon-nest</branchName>-->