### PR TITLE
Fix mobile status bar overlap and update app icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/logo-catalogue-share.svg" />
+    <link rel="icon" href="/icons/icon-192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#46a6ff" />
     <link rel="manifest" href="/manifest.json" />
-    <link rel="apple-touch-icon" href="/logo-catalogue-share.svg" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+    <link rel="mask-icon" href="/icons/icon-192.png" color="#46a6ff" />
+    <!-- For best results generate icons: npm run generate-icons (creates public/icons/*) -->
     <title>CatShare</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,6 +8,7 @@
   "icons": [
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/icon-512-maskable.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" },
     { "src": "/logo-catalogue-share.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any" }
   ]
 }

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -28,6 +28,8 @@ async function generate() {
   await ensureDir(OUT);
   await sharp(buf).resize(192, 192).png().toFile(path.join(OUT, "icon-192.png"));
   await sharp(buf).resize(512, 512).png().toFile(path.join(OUT, "icon-512.png"));
+  // Create a maskable variant (same PNG but flagged for manifest as maskable)
+  await sharp(buf).resize(512, 512).png().toFile(path.join(OUT, "icon-512-maskable.png"));
 
   // Android mipmap densities
   const android = [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,6 @@ function AppWithBackHandler() {
         boxSizing: "border-box",
         minHeight: "100%",
         backgroundColor: "#fff",
-        paddingTop: 'env(safe-area-inset-top, 0px)',
       }}
     >
       <Routes>

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,4 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Global safe-area fallback: ensure app content never goes under the native status bar */
-html, body, #root {
-  padding-top: env(safe-area-inset-top, 0px) !important;
-}
+/* Keep global styles minimal. Components handle safe-area insets themselves. */


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two key issues:
1. **Mobile layout**: Fix app content overlapping or positioning incorrectly relative to the status bar on mobile devices
2. **App icon**: Update the app to use proper icon files instead of the logo SVG for better mobile app experience

## Code changes

- **Removed global safe-area padding**: Eliminated `env(safe-area-inset-top)` from global CSS and App component to prevent inconsistent status bar spacing
- **Updated app icons**: 
  - Changed favicon and Apple touch icon from `/logo-catalogue-share.svg` to `/icons/icon-192.png`
  - Added mask-icon for Safari pinned tabs
  - Added maskable icon variant in manifest for better Android adaptive icon support
- **Enhanced icon generation**: Updated script to create maskable icon variant for Android
- **Simplified global styles**: Removed global safe-area handling to let individual components manage their own spacing

These changes ensure consistent mobile layout behavior and provide proper app icons across different platforms and contexts.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0d1ab272e16e47f19c1866ea6f4c9778/cosmos-haven)

👀 [Preview Link](https://0d1ab272e16e47f19c1866ea6f4c9778-cosmos-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0d1ab272e16e47f19c1866ea6f4c9778</projectId>-->
<!--<branchName>cosmos-haven</branchName>-->