### PR TITLE
Fix app overlaying status bar by disabling fullscreen

### DIFF
--- a/android/app/src/main/java/com/venuskids/catalogue/MainActivity.java
+++ b/android/app/src/main/java/com/venuskids/catalogue/MainActivity.java
@@ -9,16 +9,19 @@ import com.byteowls.capacitor.filesharer.FileSharerPlugin;
 
 public class MainActivity extends BridgeActivity {
   @Override
-public void onCreate(Bundle savedInstanceState) {
-  super.onCreate(savedInstanceState);
-  registerPlugin(FileSharerPlugin.class);
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    registerPlugin(FileSharerPlugin.class);
 
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-    // For Android 11 and above: draw under system bars
-    getWindow().setDecorFitsSystemWindows(false);
-  } else {
-    // For Android 10 and below: allow layout under status bar
-    getWindow().addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+    // Ensure the app does NOT draw behind the status bar.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      // Android 11+ API: have the window fit system windows (no edge-to-edge)
+      getWindow().setDecorFitsSystemWindows(true);
+    } else {
+      // Android 10 and below: clear flags that allow layout behind status bar
+      getWindow().clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
+      getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+      getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+    }
   }
-}
 }


### PR DESCRIPTION
## Purpose
Fix the issue where the app randomly overlays with the status bar by ensuring the app opens below the status bar instead of in fullscreen mode. This addresses user reports of unwanted fullscreen behavior that causes UI overlap issues.

## Code changes
- Modified `MainActivity.java` to prevent the app from drawing behind the status bar
- For Android 11+: Changed `setDecorFitsSystemWindows(false)` to `setDecorFitsSystemWindows(true)` to respect system window insets
- For Android 10 and below: Replaced `FLAG_LAYOUT_NO_LIMITS` with proper flags that clear translucent status and enable system bar backgrounds
- Added proper code formatting and comments for clarity

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0d1ab272e16e47f19c1866ea6f4c9778/mystic-sanctuary)

👀 [Preview Link](https://0d1ab272e16e47f19c1866ea6f4c9778-mystic-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0d1ab272e16e47f19c1866ea6f4c9778</projectId>-->
<!--<branchName>mystic-sanctuary</branchName>-->