### PR TITLE
Update mobile UI: blue status bar and larger logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/icons/icon-192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#46a6ff" />
+    <meta name="theme-color" content="#3b82f6" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <link rel="mask-icon" href="/icons/icon-192.png" color="#46a6ff" />
+    <link rel="mask-icon" href="/icons/icon-192.png" color="#3b82f6" />
     <!-- For best results generate icons: npm run generate-icons (creates public/icons/*) -->
     <title>CatShare</title>
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#46a6ff",
+  "theme_color": "#3b82f6",
   "icons": [
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,8 @@ function AppWithBackHandler() {
     const ensure = async () => {
       try {
         await StatusBar.setOverlaysWebView({ overlay: false });
-        await StatusBar.setStyle({ style: Style.Dark });
+        await StatusBar.setBackgroundColor({ color: '#3b82f6' });
+        await StatusBar.setStyle({ style: Style.Light });
       } catch (e) {
         console.warn("StatusBar set failed:", e);
       }

--- a/src/CatalogueApp.tsx
+++ b/src/CatalogueApp.tsx
@@ -272,10 +272,10 @@ export default function CatalogueApp({ products, setProducts, deletedProducts, s
                     e.stopPropagation();
                     setShowLogoFullscreen(true);
                   }}
-                  className="p-0 m-0 inline-flex items-center justify-center"
+                  className="p-1 m-0 inline-flex items-center justify-center"
                   aria-label="Open CatShare logo fullscreen"
                 >
-                  <img src="/logo-catalogue-share.svg" alt="Catalogue Share" className="w-8 h-8 rounded pointer-events-none" />
+                  <img src="/logo-catalogue-share.svg" alt="Catalogue Share" className="w-10 h-10 sm:w-12 sm:h-12 rounded pointer-events-none" />
                 </button>
                 <span>CatShare</span>
               </span>

--- a/src/CatalogueApp.tsx
+++ b/src/CatalogueApp.tsx
@@ -260,7 +260,7 @@ export default function CatalogueApp({ products, setProducts, deletedProducts, s
           {/* Center Title */}
           {!showSearch && (
             <h1
-              className="text-xl font-bold text-center flex-1 cursor-pointer transition-opacity duration-200"
+              className="text-xl font-bold text-center flex-1 cursor-pointer transition-opacity duration-200 flex items-center justify-center leading-none"
               onClick={() => {
                 setTab("products");
               }}

--- a/src/CatalogueApp.tsx
+++ b/src/CatalogueApp.tsx
@@ -272,10 +272,10 @@ export default function CatalogueApp({ products, setProducts, deletedProducts, s
                     e.stopPropagation();
                     setShowLogoFullscreen(true);
                   }}
-                  className="p-1 m-0 inline-flex items-center justify-center"
+                  className="p-1 m-0 inline-flex items-center justify-center shrink-0"
                   aria-label="Open CatShare logo fullscreen"
                 >
-                  <img src="/logo-catalogue-share.svg" alt="Catalogue Share" className="w-10 h-10 sm:w-12 sm:h-12 rounded pointer-events-none" />
+                  <img src="/logo-catalogue-share.svg" alt="Catalogue Share" className="w-10 h-10 sm:w-12 sm:h-12 rounded pointer-events-none object-contain shrink-0" />
                 </button>
                 <span>CatShare</span>
               </span>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses mobile UI improvements for the CatShare app:
- Implement blue status bar styling for mobile devices
- Increase logo visibility in mobile view (was appearing as a small dot)
- Fix vertical alignment of the CatShare title to be properly centered

## Code changes

- **Status bar styling**: Updated theme color from `#46a6ff` to `#3b82f6` across HTML meta tags and manifest.json, added Apple mobile web app meta tags, and configured Capacitor StatusBar with blue background and light text style
- **Logo improvements**: Increased logo size from `w-8 h-8` to `w-10 h-10` on mobile and `w-12 h-12` on larger screens, added responsive sizing and proper object containment
- **Title alignment**: Added flexbox centering classes (`flex items-center justify-center leading-none`) to properly center the CatShare title vertically

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0d1ab272e16e47f19c1866ea6f4c9778/neon-realm)

👀 [Preview Link](https://0d1ab272e16e47f19c1866ea6f4c9778-neon-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0d1ab272e16e47f19c1866ea6f4c9778</projectId>-->
<!--<branchName>neon-realm</branchName>-->