### PR TITLE
Fix status bar overlay and height issues across Android devices

### DIFF
--- a/android/app/src/main/java/com/venuskids/catalogue/MainActivity.java
+++ b/android/app/src/main/java/com/venuskids/catalogue/MainActivity.java
@@ -1,7 +1,10 @@
 package com.venuskids.catalogue;
 
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.View;
+import android.view.WindowInsetsController;
 import android.view.WindowManager;
 
 import com.getcapacitor.BridgeActivity;
@@ -13,15 +16,28 @@ public class MainActivity extends BridgeActivity {
     super.onCreate(savedInstanceState);
     registerPlugin(FileSharerPlugin.class);
 
-    // Ensure the app does NOT draw behind the status bar.
+    // Always keep webview below the status bar (no overlay) and make status bar blue with light icons
+    final int blue = Color.parseColor("#2563EB"); // matches colorPrimaryDark
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      // Android 11+ API: have the window fit system windows (no edge-to-edge)
       getWindow().setDecorFitsSystemWindows(true);
+      getWindow().setStatusBarColor(blue);
+      final WindowInsetsController c = getWindow().getInsetsController();
+      if (c != null) {
+        // Ensure light icons (white) on colored status bar
+        c.setSystemBarsAppearance(0, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+      }
     } else {
-      // Android 10 and below: clear flags that allow layout behind status bar
+      // Android 10 and below
       getWindow().clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
       getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
       getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      getWindow().setStatusBarColor(blue);
+      // Ensure light icons by clearing LIGHT_STATUS_BAR flag
+      final View decor = getWindow().getDecorView();
+      int vis = decor.getSystemUiVisibility();
+      vis &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+      decor.setSystemUiVisibility(vis);
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,7 @@ function AppWithBackHandler() {
     <div
       style={{
         boxSizing: "border-box",
-        minHeight: "100%",
+        height: "100%",
         backgroundColor: "#fff",
       }}
     >

--- a/src/CatalogueApp.tsx
+++ b/src/CatalogueApp.tsx
@@ -241,7 +241,7 @@ export default function CatalogueApp({ products, setProducts, deletedProducts, s
 
   return (
     <div
-      className="w-full h-screen flex flex-col bg-gradient-to-b from-white to-gray-100 relative"
+      className="w-full min-h-[100dvh] flex flex-col bg-gradient-to-b from-white to-gray-100 relative"
     >
 
       {tab === "products" && (

--- a/src/index.css
+++ b/src/index.css
@@ -2,4 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Root sizing to avoid overlaps and ensure full height across devices */
+html, body, #root {
+  height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: #fff;
+}
+
 /* Keep global styles minimal. Components handle safe-area insets themselves. */


### PR DESCRIPTION
## Purpose

Fix inconsistent status bar behavior across different Android devices (OnePlus, Samsung, POCO) where the app was randomly overlaying with the status bar and not displaying a consistent blue status bar color. The goal is to ensure the app displays properly on all devices with a blue status bar and the app content starting below the status bar, utilizing the full available screen height.

## Code Changes

### Android Native (MainActivity.java)
- Added proper status bar color configuration with blue color (`#2563EB`)
- Implemented device-specific handling for Android 11+ vs older versions
- Set light status bar icons for better visibility on colored background
- Ensured webview content stays below status bar (no overlay)

### Frontend (React/CSS)
- Changed app container from `minHeight: "100%"` to `height: "100%"` for consistent sizing
- Updated main component to use `min-h-[100dvh]` instead of `h-screen` for better viewport handling
- Added global CSS rules for html, body, and root elements to ensure proper height inheritance across devices
- Set consistent background color and viewport height handling

These changes provide a unified solution that addresses the random status bar overlay issues and ensures consistent behavior across all Android device types.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0d1ab272e16e47f19c1866ea6f4c9778/pixel-forge)

👀 [Preview Link](https://0d1ab272e16e47f19c1866ea6f4c9778-pixel-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0d1ab272e16e47f19c1866ea6f4c9778</projectId>-->
<!--<branchName>pixel-forge</branchName>-->